### PR TITLE
Fix dependencies and Eigen 3 support

### DIFF
--- a/docs/source/sphinx/source/howto.rst
+++ b/docs/source/sphinx/source/howto.rst
@@ -218,9 +218,9 @@ should have each of the following blocks of content in it:
     #include "dynamic_3body_model.hh"
     #include "utility.hh"
 
-    #include "Eigen/Core"
-    #include "Eigen/Dense"
-    #include "Eigen/SVD"
+    #include <eigen3/Eigen/Core>
+    #include <eigen3/Eigen/Dense>
+    #include <eigen3/Eigen/SVD>
 
     #include <chrono>
     #include <fstream>
@@ -453,7 +453,7 @@ order to keep the code tidy. In this example, we call this
 
 .. code-block:: cpp
 
-    #include "Eigen/Dense"
+    #include <eigen3/Eigen/Dense>
     #include "parameter_location_3body.hh"
     #pragma once
 

--- a/docs/source/sphinx/source/install.rst
+++ b/docs/source/sphinx/source/install.rst
@@ -13,6 +13,14 @@ Dependencies
 - C++ 14 compatible compiler
 - Git
 
+The following packages:
+- Cython3
+- Eigen3 library
+- GTest library
+- Numpy
+- Sphinx
+- Sphinx breathe (Doxygen integration)
+
 Platforms
 ###########
 
@@ -25,7 +33,7 @@ Linux
 
 3. Create and navigate into a build directory (mkdir build && cd build)
 
-4. Run CMake (cmake .. && cmake \-\-build)
+4. Run CMake (cmake .. && cmake \-\-build .)
 
 5. Run the executable of your choice (e.g, ./dcm_3body)
 
@@ -37,7 +45,7 @@ Mac
 
 3. Create and navigate into a build directory (mkdir build && cd build)
 
-4. Run CMake (cmake .. && cmake \-\-build)
+4. Run CMake (cmake .. && cmake \-\-build .)
 
 5. Run the executable of your choice (e.g, ./dcm_3body)
 

--- a/include/bma_model.hh
+++ b/include/bma_model.hh
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-#include <Eigen/Dense>
+#include <eigen3/Eigen/Dense>
 #include "utility.hh"
 
 #pragma once

--- a/include/bmr_model.hh
+++ b/include/bmr_model.hh
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-#include <Eigen/Dense>
+#include <eigen3/Eigen/Dense>
 #include "bma_model.hh"
 #include "utility.hh"
 

--- a/include/dynamic_model.hh
+++ b/include/dynamic_model.hh
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-#include <Eigen/Dense>
+#include <eigen3/Eigen/Dense>
 #pragma once
 
 /**

--- a/include/peb_model.hh
+++ b/include/peb_model.hh
@@ -13,7 +13,7 @@
  */
 
 #include <stdio.h>
-#include <Eigen/Dense>
+#include <eigen3/Eigen/Dense>
 #include <iostream>
 #include <unsupported/Eigen/KroneckerProduct>
 #include <vector>

--- a/include/tests/dynamic_3body_model_test.hh
+++ b/include/tests/dynamic_3body_model_test.hh
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-#include "Eigen/Dense"
+#include <eigen3/Eigen/Dense>
 #include "parameter_location_3body.hh"
 #pragma once
 

--- a/include/utility.hh
+++ b/include/utility.hh
@@ -11,8 +11,8 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-#include <Eigen/Dense>
-#include <Eigen/Sparse>
+#include <eigen3/Eigen/Dense>
+#include <eigen3/Eigen/Sparse>
 #include <fstream>
 #include <functional>
 #include <iostream>

--- a/python/cpp/cpp_matrixxdpy.hh
+++ b/python/cpp/cpp_matrixxdpy.hh
@@ -1,6 +1,6 @@
 #ifndef MATRIXXdPY_H
 #define MATRIXXdPY_H
-#include <Eigen/Dense>
+#include <eigen3/Eigen/Dense>
 using namespace Eigen;
 #pragma once
 

--- a/python/cpp/cpp_matrixxipy.hh
+++ b/python/cpp/cpp_matrixxipy.hh
@@ -1,6 +1,6 @@
 #ifndef MATRIXXiPY_H
 #define MATRIXXiPY_H
-#include <Eigen/Dense>
+#include <eigen3/Eigen/Dense>
 using namespace Eigen;
 #pragma once
 

--- a/python/cpp/cpp_vectorxdpy.hh
+++ b/python/cpp/cpp_vectorxdpy.hh
@@ -1,6 +1,6 @@
 #ifndef VECTORXdPY_H
 #define VECTORXdPY_H
-#include <Eigen/Dense>
+#include <eigen3/Eigen/Dense>
 #include <iostream>
 
 using namespace Eigen;

--- a/python/cpp/cpp_vectorxipy.hh
+++ b/python/cpp/cpp_vectorxipy.hh
@@ -1,6 +1,6 @@
 #ifndef VECTORXiPY_H
 #define VECTORXiPY_H
-#include <Eigen/Dense>
+#include <eigen3/Eigen/Dense>
 using namespace Eigen;
 #pragma once
 

--- a/python/cpp/dynamic_python_model.cc
+++ b/python/cpp/dynamic_python_model.cc
@@ -14,9 +14,9 @@
 #include "dynamic_python_model.hh"
 #include "utility.hh"
 
-#include "Eigen/Core"
-#include "Eigen/Dense"
-#include "Eigen/SVD"
+#include <eigen3/Eigen/Core>
+#include <eigen3/Eigen/Dense>
+#include <eigen3/Eigen/SVD>
 
 #include <numpy/arrayobject.h>
 

--- a/python/cpp/eigen_to_mv.hh
+++ b/python/cpp/eigen_to_mv.hh
@@ -1,4 +1,4 @@
-#include <Eigen/Dense>
+#include <eigen3/Eigen/Dense>
 #include <Python.h>
 #pragma once
 

--- a/python/cpp/mv_to_eigen.hh
+++ b/python/cpp/mv_to_eigen.hh
@@ -1,4 +1,4 @@
-#include <Eigen/Dense>
+#include <eigen3/Eigen/Dense>
 #pragma once
 
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,6 +1,7 @@
 from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Build import cythonize
+import numpy
 
 ext_modules = [
     Extension(
@@ -10,7 +11,7 @@ ext_modules = [
         "../src/dynamic_model.cc",
         "../src/utility.cc"
     ],
-    include_dirs = ['/usr/local/include/eigen3', '../include', 'cpp/'],
+    include_dirs = ['/usr/local/include/eigen3', '../include', 'cpp/', numpy.get_include()],
     language="c++",
     ),
 ]

--- a/src/3body/dynamic_3body_model.cc
+++ b/src/3body/dynamic_3body_model.cc
@@ -14,9 +14,9 @@
 #include "dynamic_3body_model.hh"
 #include "utility.hh"
 
-#include "Eigen/Core"
-#include "Eigen/Dense"
-#include "Eigen/SVD"
+#include <eigen3/Eigen/Core>
+#include <eigen3/Eigen/Dense>
+#include <eigen3/Eigen/SVD>
 
 #include <chrono>
 #include <fstream>

--- a/src/utility.cc
+++ b/src/utility.cc
@@ -16,8 +16,8 @@
 #include <functional>
 #include <iostream>
 #include <sstream>
-#include <unsupported/Eigen/MatrixFunctions>
-#include "Eigen/Core"
+#include <eigen3/unsupported/Eigen/MatrixFunctions>
+#include <eigen3/Eigen/Core>
 
 #define SparseMD Eigen::SparseMatrix<double>
 #define SparseVD Eigen::SparseVector<double>

--- a/tests/dynamic_3body_model_test.cc
+++ b/tests/dynamic_3body_model_test.cc
@@ -14,7 +14,7 @@
 #include "dynamic_3body_model.hh"
 #include <gtest/gtest.h>
 #include <stdio.h>
-#include <Eigen/Dense>
+#include <eigen3/Eigen/Dense>
 #include <fstream>
 #include <iostream>
 #include "bmr_model.hh"

--- a/tests/utility_test.cc
+++ b/tests/utility_test.cc
@@ -14,7 +14,7 @@
 #include "utility.hh"
 #include <gtest/gtest.h>
 #include <stdio.h>
-#include <Eigen/Dense>
+#include <eigen3/Eigen/Dense>
 #include <functional>
 #include <iostream>
 #include <unsupported/Eigen/KroneckerProduct>


### PR DESCRIPTION
The headers are now all sub-directories of eigen3.  So either this needs to be added to the include directory, or (as I have done), the headers need fixing.  There is also inconsistency in the use of '<' pr '"'.  Eigen is a system library, so should use '<'.

	* docs/source/sphinx/source/howto.rst: Update Eigen references to be inside the eigen3 directory, and consistently use '<' around includes.
	* docs/source/sphinx/source/install.rst: Add a list of all the dependencies needed.
	* include/bma_model.hh: Update Eigen references to be inside the eigen3 directory, and consistently use '<' around includes.
	* include/bmr_model.hh: Likewise.
	* include/dynamic_model.hh: Likewise.
	* include/peb_model.hh: Likewise.
	* include/tests/dynamic_3body_model_test.hh: Likewise.
	* include/utility.hh: Likewise.
	* python/cpp/cpp_matrixxdpy.hh: Likewise.
	* python/cpp/cpp_matrixxipy.hh: Likewise.
	* python/cpp/cpp_vectorxdpy.hh: Likewise.
	* python/cpp/cpp_vectorxipy.hh: Likewise.
	* python/cpp/dynamic_python_model.cc: Likewise.
	* python/cpp/eigen_to_mv.hh: Likewise.
	* python/cpp/mv_to_eigen.hh: Likewise.
	* python/setup.py: Likewise.
	* src/3body/dynamic_3body_model.cc: Likewise.
	* src/utility.cc: Likewise.
	* tests/dynamic_3body_model_test.cc: Likewise.
	* tests/utility_test.cc: Likewise.